### PR TITLE
Add a 'Quit' Button

### DIFF
--- a/include/boxer/boxer.h
+++ b/include/boxer/boxer.h
@@ -44,7 +44,8 @@ enum class Style {
 enum class Buttons {
    OK,
    OKCancel,
-   YesNo
+   YesNo,
+   Quit
 };
 
 /*!

--- a/src/boxer_linux.cpp
+++ b/src/boxer_linux.cpp
@@ -28,6 +28,8 @@ GtkButtonsType getButtonsType(Buttons buttons) {
          return GTK_BUTTONS_OK_CANCEL;
       case Buttons::YesNo:
          return GTK_BUTTONS_YES_NO;
+     case Buttons::Quit:
+         return GTK_BUTTONS_CLOSE;
       default:
          return GTK_BUTTONS_OK;
    }

--- a/src/boxer_osx.mm
+++ b/src/boxer_osx.mm
@@ -9,6 +9,7 @@ NSString* const kOkStr = @"OK";
 NSString* const kCancelStr = @"Cancel";
 NSString* const kYesStr = @"Yes";
 NSString* const kNoStr = @"No";
+NSString* const kQuitStr = @"Quit";
 
 NSAlertStyle getAlertStyle(Style style) {
    switch (style) {
@@ -38,6 +39,9 @@ void setButtons(NSAlert *alert, Buttons buttons) {
          [alert addButtonWithTitle:kYesStr];
          [alert addButtonWithTitle:kNoStr];
          break;
+     case Buttons::Quit:
+         [alert addButtonWithTitle:kQuitStr];
+       break;
       default:
          [alert addButtonWithTitle:kOkStr];
    }

--- a/src/boxer_win.cpp
+++ b/src/boxer_win.cpp
@@ -23,6 +23,7 @@ UINT getIcon(Style style) {
 UINT getButtons(Buttons buttons) {
    switch (buttons) {
       case Buttons::OK:
+      case Buttons::Quit: // There is no 'Quit' button on windows :(
          return MB_OK;
       case Buttons::OKCancel:
          return MB_OKCANCEL;


### PR DESCRIPTION
If Boxer is used to show the user a fatal error dialog it is more
intuitive to show an 'Quit' button instead of an 'OK' button, since the
only option is to quit the application. This commits adds
boxer::Buttons::Quit. Since there is no such option on Windows or gtk, it shows
the 'OK' button on Windows and the 'Close' button for gtk instead. 
