### PR TITLE
message box to appear on top of other windows on Linux

### DIFF
--- a/src/boxer_linux.cpp
+++ b/src/boxer_linux.cpp
@@ -77,6 +77,10 @@ Selection show(const char* message, const char* title, Style style, Buttons butt
                                               "%s",
                                               message);
    gtk_window_set_title(GTK_WINDOW(dialog), title);
+
+   // Keep the dialog on top of other windows
+   gtk_window_set_keep_above(GTK_WINDOW(dialog), TRUE);
+
    Selection selection = getSelection(gtk_dialog_run(GTK_DIALOG(dialog)));
 
    gtk_widget_destroy(GTK_WIDGET(dialog));


### PR DESCRIPTION
Hi there, this is just a change, similar to the mac implementation, that will make the message boxes to appear on top of other windows on Linux.

Let me know if you need anything else that I can help with.