### PR TITLE
Explicitly center the dialog in Linux

### DIFF
--- a/src/boxer_linux.cpp
+++ b/src/boxer_linux.cpp
@@ -77,6 +77,12 @@ Selection show(const char* message, const char* title, Style style, Buttons butt
                                               "%s",
                                               message);
    gtk_window_set_title(GTK_WINDOW(dialog), title);
+
+   gtk_window_set_gravity(GTK_WINDOW(parent), GDK_GRAVITY_CENTER);
+   gtk_window_set_gravity(GTK_WINDOW(dialog), GDK_GRAVITY_CENTER);
+   gtk_window_set_position(GTK_WINDOW(parent), GTK_WIN_POS_CENTER);
+   gtk_window_set_position(GTK_WINDOW(dialog), GTK_WIN_POS_CENTER);
+
    Selection selection = getSelection(gtk_dialog_run(GTK_DIALOG(dialog)));
 
    gtk_widget_destroy(GTK_WIDGET(dialog));


### PR DESCRIPTION
On a system without a DE and only a Xorg and simple WM server those changes were necessary to have the dialog appear in the center.